### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def get_scraper(url):
     """Factory function to select the correct scraper based on the URL."""
     if "tokybook.com" in url:
         return TokybookScraper()
-    if "goldenaudiobook.net" in url:
+    if "goldenaudiobook" in url:
         return GoldenAudiobookScraper()
     if "zaudiobooks.com" in url:
         return ZaudiobooksScraper()


### PR DESCRIPTION
Fixed domain matching to be more broad for goldenaudiobook 

The GoldenAudiobook site is now using .com and the plural GoldenAudioBooks in addition to .net. Updated the scraper factory to match the broader domain so the existing scraper remains functional.

(I ran into files linked to goldenaudiobooks.com as opposed to goldenaudiobook.net)